### PR TITLE
pipeline: use NoValue instead of double quotes

### DIFF
--- a/pipeline/pipeline.yaml
+++ b/pipeline/pipeline.yaml
@@ -159,7 +159,7 @@ Resources:
             ChangeSetName: pipeline-changeset
             Capabilities: CAPABILITY_NAMED_IAM
             TemplatePath: !Sub "${AppName}-BuildArtifact::${SAMOutputFile}"
-            TemplateConfiguration: !If [ HasStagingVariables, !Sub "${AppName}-BuildArtifact::${StagingFile}", "" ]
+            TemplateConfiguration: !If [ HasStagingVariables, !Sub "${AppName}-BuildArtifact::${StagingFile}", !Ref "AWS::NoValue" ]
           RunOrder: 1
         - Name: execute-changeset
           InputArtifacts: []


### PR DESCRIPTION
Cloudformation will fail due to parameter constraints when using double
quotes.