### PR TITLE
Updated runtime parameter.

### DIFF
--- a/api/saml.yaml
+++ b/api/saml.yaml
@@ -11,7 +11,7 @@ Resources:
         Type: AWS::Serverless::Function
         Properties:
             Handler: index.handler
-            Runtime: nodejs4.3
+            Runtime: nodejs8.10
             CodeUri: ./
             Environment:
                 Variables:


### PR DESCRIPTION
Using runtime nodej4.3 failed with the following error in AWS CloudFormation: The runtime parameter of nodejs4.3 is no longer supported for creating or updating AWS Lambda functions.
Changed to nodejs8.10 and it worked.